### PR TITLE
Fix Dockerfile and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.suse.com/bci/nodejs
 ARG CONTAINER_USERID
 
 # Install requirements and add user
-RUN zypper -n install --no-recommends mkisofs && useradd -m -d /fuelignition fuelignition -u ${CONTAINER_USERID}
+RUN zypper -n install --no-recommends mkisofs python3 make gcc gcc-c++ && useradd -m -d /fuelignition fuelignition -u ${CONTAINER_USERID}
 
 COPY --chown=fuelignition . /fuelignition/
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run dev
 ```
 $ sudo zypper in podman
 $ make
-$ podman run --network=host fuelignition:latest
+$ podman run --rm --network=host fuelignition:latest
 
 > fuel-ignition@1.0 dev
 > vite


### PR DESCRIPTION
Add some missing dependencies to the Dockerfile to make it work with `make`.

Also update the `podman run` command in the Local Development in a container section to include the `--rm` parameter to prevent dangling container resources while testing.

This resolves https://github.com/openSUSE/fuel-ignition/issues/19