### PR TITLE
Allow comma and spaces in zypper list

### DIFF
--- a/src/components/forms/combustion/CombInstallPackageForm.vue
+++ b/src/components/forms/combustion/CombInstallPackageForm.vue
@@ -4,12 +4,12 @@
   <div class="combustioninstall">
     <FormKit
       :name="formKey('package_name')"
-      label="Name of the package you want to install"
+      label="Packages you want to install (space or comma separated)"
       type="text"
       validation="required"
       validation-behavior="live"
       value="vim-small"
-      help="This will add the line 'zypper --non-interactive install {package name}' to the combustion script."
+      help="This will add a 'zypper --non-interactive install [packages]' line to the combustion script."
     />
   </div>
 </template>
@@ -35,7 +35,7 @@ export default {
         .filter((x) => x.includes(formPrefix))
         .forEach((key) => {
           json.combustion +=
-            "\nzypper --non-interactive install " + formData[key];
+            "\nzypper --non-interactive install " + Utils.normalizeZypperPackages(formData[key]);
         });
     },
   },

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -77,4 +77,11 @@ export default {
   getFormValue: function (prefix, formData, key, uid) {
     return formData[this.getFormKey(prefix, key, uid)];
   },
+
+  /* normalizeZypperPackages acceps a text representing a list of zypper packages, separated either by comma or by space, and returns a tidy string with all packages separated by a single space */
+  normalizeZypperPackages : function(txt) {
+    return txt.split(/[ ,]/) // split by space or comma
+    .filter(n => n)          // filter empty elements
+    .join(" ");              // return string of packages separated by a single space
+  },
 };


### PR DESCRIPTION
Simplify the installation of package defitions for combustion by allowing users to insert multiple packages, separated either by space or by comma.

This should make it easier to users to select multiple packages, because the text field does not require the knowledge that the package list will be directly used in zypper, but it allows a more human-natural way of entering comma separated items.