### PR TITLE
Make TOTP code usage on SUSE platforms much clearer 

### DIFF
--- a/src/components/forms/AddUsersForm.vue
+++ b/src/components/forms/AddUsersForm.vue
@@ -50,7 +50,7 @@
       type="checkbox"
       validation="required"
       validation-behavior="live "
-      help="Enabling Two-Factor Authentication (2FA) via an app based authenticator."
+      help="Enabling Two-Factor Authentication (2FA) via an app based authenticator. This is for use with Cockpit on SUSE related systems. Please note Cockpit disallows root login by default."
       v-model="totpEnabled"
     />
 
@@ -59,7 +59,7 @@
         :name="formKey('totp_secret')"
         type="text"
         label="Time-based one-time password (TOTP) Secret"
-        :help="`Your secret (written to file /${(name === 'root' ? '' : 'home/') + name}/.pam_oath_usersfile) is never sent over the internet. It will be used e.g. with Cockpit and allows a 2fa authentication via an app based authenticator. The following QR-Code defines how the app generates the code:`"
+        :help="`Your secret (written to file /${(name === 'root' ? '' : 'home/') + name}/.pam_oath_usersfile) is never sent over the internet. The following QR-Code defines how the app generates the code:`"
         v-model="secret"
       />
 


### PR DESCRIPTION
This works off @rsimai's changes in #47 so those need to be merged first but this should apply cleanly once it has been. Let me know if I need to handle this a different way